### PR TITLE
Feature/fix auth endpoint

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -38,12 +38,7 @@ async def register(user_data: UserRegister, db: AsyncSession = Depends(get_db)):
     )
     db.add(new_user)
     await db.commit() #SQLAlchemy puts that user object into a Session where it stages the changes to the database.
-
-    #creating jwt token
-    token = create_access_token(data={"sub": user_data.email})
-
-    #retunr token to react native
-    return Token(access_token=token, token_type="bearer")
+    return new_user
 
 @router.post("/login")
 async def login(credentials: UserLogin, db: AsyncSession = Depends(get_db)):

--- a/backend/app/routes/workout.py
+++ b/backend/app/routes/workout.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from typing import List
 
 from app.db import get_db
@@ -9,6 +10,24 @@ from app.models.exercise import Exercise
 from app.schemas.workout import WorkoutResponse, WorkoutSummary
 
 router = APIRouter(prefix="/workouts", tags=["Workouts"])
+
+
+@router.get("/category/{category}", response_model=List[WorkoutSummary])
+async def get_workouts_by_category(
+        category: str,
+        db: AsyncSession = Depends(get_db)
+):
+
+#Get workouts by category.
+    result = await db.execute(
+        select(Workout)
+        .where(Workout.category == category)
+        .where(Workout.is_preset == True)
+        .order_by(Workout.created_at.desc())
+    )
+    workouts = result.scalars().all()
+
+    return workouts
 
 
 @router.get("/", response_model=List[WorkoutSummary])
@@ -37,7 +56,10 @@ async def get_workout_detail(
 ):
 #    Get specific workout with all exercises.
     result = await db.execute(
-        select(Workout).where(Workout.id == workout_id)
+        select(Workout)
+        .options(selectinload(Workout.exercises))
+        .where(Workout.id == workout_id)
+
     )
     workout = result.scalars().first()
 
@@ -49,20 +71,3 @@ async def get_workout_detail(
 
     return workout
 
-
-@router.get("/category/{category}", response_model=List[WorkoutSummary])
-async def get_workouts_by_category(
-        category: str,
-        db: AsyncSession = Depends(get_db)
-):
-
-#Get workouts by category.
-    result = await db.execute(
-        select(Workout)
-        .where(Workout.category == category)
-        .where(Workout.is_preset == True)
-        .order_by(Workout.created_at.desc())
-    )
-    workouts = result.scalars().all()
-
-    return workouts

--- a/backend/app/schemas/exercise.py
+++ b/backend/app/schemas/exercise.py
@@ -8,8 +8,8 @@ class ExerciseBase(BaseModel):
     name: str
     gif_url: Optional[str] = None
     sets: int
-    reps: str
-    rest_seconds: Optional[int] = 60
+    reps: int
+    rest_period_seconds: Optional[int] = 60
     order: int
     notes: Optional[str] = None
 

--- a/backend/app/schemas/workout.py
+++ b/backend/app/schemas/workout.py
@@ -18,6 +18,7 @@ class WorkoutCreate(WorkoutBase):
 #wokout data going to front end
 class WorkoutResponse(WorkoutBase):
     id: int
+    category:str
     is_preset: bool
     created_at: datetime
     exercises: List[ExerciseResponse] = []

--- a/backend/scripts/seed_workouts.py
+++ b/backend/scripts/seed_workouts.py
@@ -34,10 +34,10 @@ async def seed_chest_triceps():
                 name="Barbell Bench Press",
                 gif_url="https://v2.exercisedb.io/image/0025",
                 sets=4,
-                reps=8-12,
+                reps=10,
                 rest_period_seconds=90,
                 order=1,
-                notes="Focus on controlled descent, touch chest lightly"
+                notes="Focus on controlled descent, touch chest lightly (8-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -45,10 +45,10 @@ async def seed_chest_triceps():
                 name="Incline Dumbbell Press",
                 gif_url="https://v2.exercisedb.io/image/0033",
                 sets=3,
-                reps=10-12,
+                reps=10,
                 rest_period_seconds=60,
                 order=2,
-                notes="45-degree angle, full range of motion"
+                notes="45-degree angle, full range of motion (10-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -56,10 +56,10 @@ async def seed_chest_triceps():
                 name="Cable Chest Fly",
                 gif_url="https://v2.exercisedb.io/image/0108",
                 sets=3,
-                reps=12-15,
+                reps=12,
                 rest_period_seconds=45,
                 order=3,
-                notes="Squeeze at peak contraction"
+                notes="Squeeze at peak contraction(10-12)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -67,10 +67,10 @@ async def seed_chest_triceps():
                 name="Tricep Dips",
                 gif_url="https://v2.exercisedb.io/image/0456",
                 sets=3,
-                reps=10-12,
+                reps=10,
                 rest_period_seconds=60,
                 order=4,
-                notes="Lean forward slightly for chest, upright for triceps"
+                notes="Lean forward slightly for chest, upright for triceps(10-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -78,10 +78,10 @@ async def seed_chest_triceps():
                 name="Overhead Tricep Extension",
                 gif_url="https://v2.exercisedb.io/image/0789",
                 sets=3,
-                reps=12-15,
+                reps=12,
                 rest_period_seconds=45,
                 order=5,
-                notes="Keep elbows close to head"
+                notes="Keep elbows close to head(10-12 reps)"
             ),
         ]
 
@@ -115,10 +115,10 @@ async def seed_back_biceps():
                 name="Barbell Deadlift",
                 gif_url="https://v2.exercisedb.io/image/0027",
                 sets=4,
-                reps=6-8,
+                reps=8,
                 rest_period_seconds=120,
                 order=1,
-                notes="Maintain neutral spine, drive through heels"
+                notes="Maintain neutral spine, drive through heels(6-8 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -126,10 +126,10 @@ async def seed_back_biceps():
                 name="Pull-ups",
                 gif_url="https://v2.exercisedb.io/image/0142",
                 sets=4,
-                reps=8-10,
+                reps=10,
                 rest_period_seconds=90,
                 order=2,
-                notes="Full extension at bottom, chin over bar at top"
+                notes="Full extension at bottom, chin over bar at top(8-10 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -137,10 +137,10 @@ async def seed_back_biceps():
                 name="Barbell Row",
                 gif_url="https://v2.exercisedb.io/image/0234",
                 sets=3,
-                reps=10-12,
+                reps=10,
                 rest_period_seconds=60,
                 order=3,
-                notes="Pull to lower chest, squeeze shoulder blades"
+                notes="Pull to lower chest, squeeze shoulder blades(10-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -148,10 +148,10 @@ async def seed_back_biceps():
                 name="Barbell Curl",
                 gif_url="https://v2.exercisedb.io/image/0567",
                 sets=3,
-                reps=10-12,
+                reps=10,
                 rest_period_seconds=45,
                 order=4,
-                notes="No swinging, control the negative"
+                notes="No swinging, control the negative(10-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -159,10 +159,10 @@ async def seed_back_biceps():
                 name="Hammer Curls",
                 gif_url="https://v2.exercisedb.io/image/0890",
                 sets=3,
-                reps=12-15,
+                reps=12,
                 rest_period_seconds=45,
                 order=5,
-                notes="Targets brachialis for arm thickness"
+                notes="Targets brachialis for arm thickness(12-15 reps)"
             ),
         ]
 
@@ -196,10 +196,10 @@ async def seed_legs():
                 name="Barbell Squat",
                 gif_url="https://v2.exercisedb.io/image/0043",
                 sets=4,
-                reps=8-10,
+                reps=8,
                 rest_period_seconds=120,
                 order=1,
-                notes="Depth to parallel or below, knees track over toes"
+                notes="Depth to parallel or below, knees track over toes(8-10 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -207,10 +207,10 @@ async def seed_legs():
                 name="Romanian Deadlift",
                 gif_url="https://v2.exercisedb.io/image/0345",
                 sets=3,
-                reps=10-12,
+                reps=10,
                 rest_period_seconds=90,
                 order=2,
-                notes="Feel the stretch in hamstrings, slight knee bend"
+                notes="Feel the stretch in hamstrings, slight knee bend(10-12 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -218,10 +218,10 @@ async def seed_legs():
                 name="Leg Press",
                 gif_url="https://v2.exercisedb.io/image/0678",
                 sets=3,
-                reps=12-15,
+                reps=12,
                 rest_period_seconds=60,
                 order=3,
-                notes="Full range of motion, don't lock knees"
+                notes="Full range of motion, don't lock knees(12-15 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -229,10 +229,10 @@ async def seed_legs():
                 name="Leg Curl",
                 gif_url="https://v2.exercisedb.io/image/0901",
                 sets=3,
-                reps=12-15,
+                reps=15,
                 rest_period_seconds=45,
                 order=4,
-                notes="Squeeze hamstrings at peak"
+                notes="Squeeze hamstrings at peak(12-15 reps)"
             ),
             Exercise(
                 workout_id=workout.id,
@@ -240,10 +240,10 @@ async def seed_legs():
                 name="Calf Raises",
                 gif_url="https://v2.exercisedb.io/image/1234",
                 sets=4,
-                reps=15-20,
+                reps=15,
                 rest_period_seconds=45,
                 order=5,
-                notes="Full stretch at bottom, hold peak for 1 sec"
+                notes="Full stretch at bottom, hold peak for 1 sec(15-20 reps"
             ),
         ]
 


### PR DESCRIPTION
In today's surprise demo, I noticed the auth/register endpoint was returning an access token. I went ahead and fixed it-- it now returns the correct data. 

Ex:
Response body
{
  "email": "user4@example.com",
  "username": "string4",
  "hashed_password": "$2b$12$H9Zntz4Hv9p5dtrwU/QwEeBNZwwA6QMP1n..Ih4sFCDKJS6ChD2Ta",
  "id": 11,
  "created_at": "2026-03-20T01:44:07.444589+00:00",
  "is_active": true
}