### PR TITLE
fix: revert register to email+password only, keep fitness profile fields

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -50,8 +50,6 @@ async def register(
         # Create the empty profile
         new_profile = UserProfile(
             user_id=new_user.id,
-            user_name=user_data.username,
-            full_name=user_data.full_name
         )
         db.add(new_profile)
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -13,8 +13,6 @@ class UserRegister(BaseModel):
     Data coming FROM React Native during registration.
     """
     email: EmailStr
-    username: str
-    full_name: Optional[str] = None
     password: str
     def password_strength(cls, v):
         if len(v) == 0:


### PR DESCRIPTION
kept these changes from Still:
user_profiles fitness fields - weight, last_workout, current_workout, total_workouts, day_streak (useful for profile screen)
ProfileUpdate schema additions - weight, last_workout, current_workout
ProfileResponse additions - all the new fields
users.py username uniqueness fix - cleaner check
The alembic migration for the new columns

